### PR TITLE
add note to move racial information

### DIFF
--- a/src/Earthdawn/Races.hs
+++ b/src/Earthdawn/Races.hs
@@ -14,6 +14,7 @@ data Race = Dwarf
           | T'Skrang
           | Windling
 
+-- TODO Move to configuration files?
 startingAttributes :: Race -> Attributes
 startingAttributes Dwarf     = Attributes { dexterity  =  9
                                           , strength   = 10


### PR DESCRIPTION
At some point, when we have a main and a server and everything else,
we'll want this information loaded from data files or configuration
files so that they can be changed without a new release of the software.