### PR TITLE
factor Error construction out of collection404

### DIFF
--- a/src/Earthdawn/FourthEdition/Races/API.hs
+++ b/src/Earthdawn/FourthEdition/Races/API.hs
@@ -22,6 +22,7 @@ import Servant
 
 import qualified Data.Text as T (pack)
 
+import Data.CollectionJSON
 import Earthdawn.FourthEdition.Races.Queries
 import Earthdawn.FourthEdition.Races.Types
 import Errors
@@ -43,6 +44,11 @@ races = return . flip RaceCollection playerRaces
 
 race :: URI -> String -> Handler RaceCollection
 race u n =
-  do when (isNothing r) $ throwError $ collection404 u (Just . T.pack $ "Race, " ++ n ++ ", Not Found") (Just "404") Nothing
+  do when (isNothing r) $ throwError $ collection404 u e
      return $ RaceCollection u [fromJust r]
   where r = fromName n
+        e = Error
+              { eTitle   = Just . T.pack $ "Race, " ++ n ++ ", Not Found"
+              , eCode    = Just "404"
+              , eMessage = Nothing
+              }

--- a/src/Errors.hs
+++ b/src/Errors.hs
@@ -12,15 +12,14 @@ and in various formats.
 module Errors where
 
 import Data.Aeson (encode)
-import Data.Text (Text)
 import Network.HTTP.Types.Header
 import Network.URI (URI)
 import Servant
 
 import Data.CollectionJSON
 
-collection404 :: URI -> Maybe Text -> Maybe Text -> Maybe Text -> ServantErr
-collection404 u t c m = err404
+collection404 :: URI -> Error -> ServantErr
+collection404 u e = err404
   { errHeaders = [ (hContentType, "application/vnd.collection+json") ]
   , errBody    = encode Collection
                    { cVersion  = "1.0"
@@ -29,10 +28,6 @@ collection404 u t c m = err404
                    , cItems    = []
                    , cQueries  = []
                    , cTemplate = Nothing
-                   , cError    = Just Error
-                                   { eTitle   = t
-                                   , eCode    = c
-                                   , eMessage = m
-                                   }
+                   , cError    = Just e
                    }
   }


### PR DESCRIPTION
The body and interaction with collection404 was a little clunky with so
many arguments.  By passing the Error directly it's simpler and allows
for local bindings to aid readability of error creations.  This might
even pave the way for passing the error in and making this function more
generic.