### PR TITLE
add pragmas to ignore orphans in Internal

### DIFF
--- a/src/Internal/Network/HTTP/Media.hs
+++ b/src/Internal/Network/HTTP/Media.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 {-|
 Module      : Internal.Network.HTTP.Media
 Description : HTTP Media Helper Functions

--- a/src/Internal/Network/HTTP/Types.hs
+++ b/src/Internal/Network/HTTP/Types.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 {-# LANGUAGE TypeSynonymInstances #-}
 
 {-|

--- a/src/Internal/Network/URI.hs
+++ b/src/Internal/Network/URI.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 {-|
 Module      : Internal.Network.URI
 Description : URI Helper Functions


### PR DESCRIPTION
We setup instances locally for several networking types but can switch
to library implementations if they become available.  This ignores the
warning about the instances being orphaned.