### PR TITLE
add nix configurations for development

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,11 @@
+{ nixpkgs ? import <nixpkgs> { }
+, compiler ? "default"
+}:
+let
+  inherit (nixpkgs) pkgs;
+
+  haskellPackages = if compiler == "default"
+                       then pkgs.haskellPackages
+                       else pkgs.haskell.packages.${compiler};
+in
+  haskellPackages.callPackage ./dungeon-studio.nix { }

--- a/dungeon-studio.nix
+++ b/dungeon-studio.nix
@@ -1,0 +1,28 @@
+{ mkDerivation, aeson, base, bytestring, containers, data-default
+, either, envy, exceptions, hasbolt, http-api-data, http-media
+, http-types, MissingH, mtl, network-uri, QuickCheck
+, quickcheck-instances, resource-pool, retry, servant
+, servant-server, stdenv, test-invariant, text, time
+, unordered-containers, uuid, warp
+}:
+mkDerivation {
+  pname = "dungeon-studio";
+  version = "0.1.0.0";
+  src = ./.;
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [
+    aeson base bytestring containers data-default either envy
+    exceptions hasbolt http-api-data http-media http-types MissingH mtl
+    network-uri resource-pool retry servant servant-server text time
+    unordered-containers uuid warp
+  ];
+  testHaskellDepends = [
+    aeson base bytestring containers http-api-data http-media
+    http-types MissingH network-uri QuickCheck quickcheck-instances
+    test-invariant text unordered-containers
+  ];
+  homepage = "https://github.com/alunduil/dungeon.studio";
+  description = "Game Master's Companion";
+  license = stdenv.lib.licenses.mit;
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,11 @@
+{ nixpkgs ? import <nixpkgs> { }
+, compiler ? "default"
+}:
+let
+  inherit (nixpkgs) pkgs;
+
+  haskellPackages = if compiler == "default"
+                       then pkgs.haskellPackages
+                       else pkgs.haskell.packages.${compiler};
+in
+  (import ./default.nix { inherit nixpkgs compiler; }).env


### PR DESCRIPTION
These configurations are just a convenience for people with nix
installed on their machines.  It allows one to nix-shell and have the
stack ready to roll.  I'll be extending this to include behave and other
tools for the system tests until a better integration can be figured
out.