### PR TITLE
change character creation to application/json

### DIFF
--- a/src/Earthdawn/FourthEdition/Characters/Types.hs
+++ b/src/Earthdawn/FourthEdition/Characters/Types.hs
@@ -54,7 +54,7 @@ instance ToEntity CharacterCollection where
                              , aMethod = methodPost
                              , aHref   = u
                              , aTitle  = Just "Create Character"
-                             , aType   = Just $ "application" // "x-www-form-urlencoded"
+                             , aType   = Just $ "application" // "json"
                              , aFields = [ Field { fName = "discipline", fClass = [], fType = URL, fValue = Nothing, fTitle = Just "Discipline" }
                                          , Field { fName = "race", fClass = [], fType = URL, fValue = Nothing, fTitle = Just "Race" }
                                          ]


### PR DESCRIPTION
It's far easier for clients to send application/json than form encoded
data.  Both will continue to work but the client will be informed about
the JSON requirement.